### PR TITLE
feat: add engineering and sensors interfaces

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/sensors/hydrographic_msgs"]
-	path = packages/sensors/hydrographic_msgs
-	url = git@github.com:Greenroom-Robotics/hydrographic_msgs.git

--- a/packages/engineering/CMakeLists.txt
+++ b/packages/engineering/CMakeLists.txt
@@ -1,0 +1,53 @@
+# All rights reserved.
+cmake_minimum_required(VERSION 3.5)
+
+### Export std_msgs/Headers
+project(maritime_interfaces_engineering)
+
+# Generate messages
+find_package(ament_cmake_auto REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(maritime_interfaces_support REQUIRED)
+
+ament_auto_find_build_dependencies()
+
+set(ENGINE_INTERFACES
+  engine/EngineConfig.msg
+  engine/EngineControl.msg
+  engine/EngineState.msg
+)
+
+set(GEARBOX_INTERFACES
+  gearbox/GearboxConstants.msg
+  gearbox/GearboxControl.msg
+  gearbox/GearboxState.msg
+)
+
+set(HELM_INTERFACES
+  helm/HelmControl.msg
+  helm/HelmState.msg
+)
+
+set(THRUSTER_INTERFACES
+  thruster/ThrusterControl.msg
+  thruster/ThrusterState.msg
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+    ${ENGINE_INTERFACES}
+    ${GEARBOX_INTERFACES}
+    ${HELM_INTERFACES}
+    ${THRUSTER_INTERFACES}
+
+  DEPENDENCIES
+    "std_msgs"
+    "maritime_interfaces_support"
+  ADD_LINTER_TESTS
+)
+
+if(BUILD_TESTING)
+
+endif()
+
+ament_auto_package()
+

--- a/packages/engineering/package.xml
+++ b/packages/engineering/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>maritime_interfaces_engineering</name>
+  <version>0.0.1</version>
+  <description>Engineering</description>
+  <maintainer email="team@greenroomrobotics.com">Greenroom Robotics</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <depend>std_msgs</depend>
+  <depend>maritime_interfaces_support</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/packages/sensors/CMakeLists.txt
+++ b/packages/sensors/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(maritime_interfaces_sensors)
+
+find_package(ament_cmake_auto REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(ais_msgs REQUIRED)
+find_package(geolocation_msgs REQUIRED)
+find_package(acoustic_msgs REQUIRED)
+find_package(environmental_msgs REQUIRED)
+
+ament_auto_find_build_dependencies()
+
+ament_auto_package()

--- a/packages/sensors/package.xml
+++ b/packages/sensors/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>maritime_interfaces_sensors</name>
+  <version>0.0.1</version>
+  <description>Metapackage for maritime sensor interfaces</description>
+  <maintainer email="team@greenroomrobotics.com">Greenroom Robotics</maintainer>
+  <license>MIT</license>
+
+  <depend>sensor_msgs</depend>
+  <depend>ais_msgs</depend>
+  <depend>geolocation_msgs</depend>
+  <depend>acoustic_msgs</depend>
+  <depend>environmental_msgs</depend>
+
+
+ <buildtool_depend>ament_cmake</buildtool_depend>
+ <test_depend>ament_lint_auto</test_depend>
+ <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
- maritime_interfaces_engineering
- maritime_interfaces_sensors
   - hydrographic_msgs are now packaged up in our fork - [Greenroom-Robotics/hydrographic_msgs](https://github.com/Greenroom-Robotics/hydrographic_msgs) 